### PR TITLE
Refactor layout to use page scrolling and sticky footer

### DIFF
--- a/frontend/src/app/shared/components/layout/layout.component.html
+++ b/frontend/src/app/shared/components/layout/layout.component.html
@@ -1,6 +1,6 @@
-<div class="flex flex-col h-screen" id="top">
+<div class="flex flex-col min-h-screen" id="top">
 
-  <header class="header w-full fixed top-0 h-15 flex-grow  pt-4 pr-2 z-3" role="banner">
+  <header class="header w-full h-15  pt-4 pr-2 z-3" role="banner">
     <div class="flex flex-row">
       <nav class="flex-none" aria-label="Breadcrumb navigation">
         @if (true) {
@@ -52,10 +52,10 @@
     </div>
 
   </header>
-  <div class="flex-1 flex flex-col pt-12 pb-12 min-h-0">
+  <div class="flex-1 flex flex-col">
     <router-outlet />
   </div>
-  <footer class="footer fixed bottom-0 w-full h-12 p-3 flex justify-center items-center z-3 gap-2" role="contentinfo">
+  <footer class="footer h-12 p-3 flex justify-center items-center z-3 gap-2" role="contentinfo">
 
     <a href="/blog/legal" class="link-primary px-2 py-2 inline-block"
       title="Read PianoML legal notice and terms of use">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -244,14 +244,12 @@ router-outlet + * {
 	flex: 1 1 0%;
 	display: flex;
 	flex-direction: column;
-	min-height: 0;
 }
 
 .main-article {
 	@apply flex flex-col flex-1 ;
-	min-height: 0;
 }
 
 .main-section {
-	@apply bg-neutral-700 p-4 flex-1 overflow-y-auto;
+	@apply bg-neutral-700 p-4 flex-1;
 }


### PR DESCRIPTION
The application layout was using a fixed-height viewport (`h-screen`) with an internal scrollable section (`.main-section`). This resulted in the footer always being visible but often obstructing or feeling disconnected from the content flow.

This change refactors the layout to use a standard document-flow scrolling approach:
1.  **Layout Template**: Changed the main container from `h-screen` to `min-h-screen`. Removed `fixed` positioning from the header and footer.
2.  **Global Styles**: Removed `overflow-y-auto` from `.main-section` so the entire page scrolls. Removed `min-height: 0` from `.main-article` and the router-outlet sibling to allow them to expand naturally with content.
3.  **Sticky Footer**: Used Flexbox properties (`flex-col` on the container and `flex-1` on the content wrapper) to ensure the footer remains at the bottom of the viewport even on short pages.

These changes provide a more UX-friendly experience by allowing the user to scroll to the bottom of the page to see the footer, and by making the scroll behavior consistent with standard web patterns.

---
*PR created automatically by Jules for task [14830598401394979081](https://jules.google.com/task/14830598401394979081) started by @eflorent2020*